### PR TITLE
Bump version

### DIFF
--- a/lib/moltrio/config/version.rb
+++ b/lib/moltrio/config/version.rb
@@ -1,5 +1,5 @@
 module Moltrio
   module Config
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
After yanking version 0.1.3 from Rubygems

```
bundle exec rake release
...
A yanked version already exists (moltrio-config-0.1.3).
Repushing of gem versions is not allowed. Please use a new version and retry
```